### PR TITLE
Accept str or unicode for val

### DIFF
--- a/rados.py
+++ b/rados.py
@@ -380,8 +380,8 @@ Rados object in state %s." % self.state)
         self.require_state("configuring", "connected")
         if not isinstance(option, str):
             raise TypeError('option must be a string')
-        if not isinstance(val, str):
-            raise TypeError('val must be a string')
+        if not isinstance(val, str) and not isinstance(val, unicode):
+            raise TypeError('val must be a string or unicode')
         ret = run_in_thread(self.librados.rados_conf_set,
                             (self.cluster, c_char_p(option), c_char_p(val)))
         if (ret != 0):


### PR DESCRIPTION
A unicode object is also a valid object type for val.  This is
particularly noticeable when a python3 (or python2 + six) module is
referencing this object.  The values from python3 are unicode instead of
string.